### PR TITLE
added new filter sorting

### DIFF
--- a/src/app/shared/components/search-filter/search-filter/search-filter.component.ts
+++ b/src/app/shared/components/search-filter/search-filter/search-filter.component.ts
@@ -45,14 +45,26 @@ export class SearchFilterComponent implements OnInit {
   }
 
   private filterOptions(options: string[], value: string): string[] {
-    if (value){
+    if (value) {
       const filterValue = value.toLowerCase();
-
-      // TODO improve this filter to sort by best match
-      return options.filter(option => option.toLowerCase().includes(filterValue));
-    } else {
-      return options;
+      options = options.filter(option => option.toLowerCase().includes(filterValue));
+      options.sort((a, b) => {
+        // if index of somehow turns to bottleneck KMP can be used
+        const idA: number = a.indexOf(filterValue);
+        const idB: number = b.indexOf(filterValue);
+        if (idA == idB) {
+          if (a.length == b.length) {
+            return a.localeCompare(b);
+          } else {
+            return a.length - b.length;
+          }
+        } else {
+          return idA - idB;
+        }
+      })
     }
+    
+    return options;
   }
 
   onOptionSelected(choice: string){


### PR DESCRIPTION
Algorytm jest następujący: 
 - sortowanie po przesunięciu, jeśli remis to
 - sortowanie po długości wyrazu, jeśli remis to
 - sortowanie alfabetyczne.
 
Można użyć fancy algosa, ale wydaje mi się, że ogólnie zysk nie będzie duży, a trochę zaciemni to kod. Poniżej przykładowy benchmark różnych metod, polegający na wyszukiwaniu  wszystkich (a nie pierwszego jak u nas) "art" w ustawie, która ma ~3000 linijek [s]. afaik index of używa naiwnego.

![image](https://user-images.githubusercontent.com/73036080/165138751-70381f42-abde-4f83-8fb1-ff3274821477.png)

Przykładowy case pokazujący, że obecna wersja działa nieźle:

![image](https://user-images.githubusercontent.com/73036080/165138821-4da2b2c5-f799-4eaf-8e03-9ad322ebc2a0.png)

Przykładowy średni case (wyrazy poza 1. są niealfabetyczne). 

![image](https://user-images.githubusercontent.com/73036080/165138900-cf1c9f8d-3c42-46c6-bc65-82cb685a1ee7.png)
