### PR TITLE
Filter options sorting bug fix

### DIFF
--- a/src/app/shared/components/search-filter/search-filter/search-filter.component.ts
+++ b/src/app/shared/components/search-filter/search-filter/search-filter.component.ts
@@ -53,8 +53,8 @@ export class SearchFilterComponent implements OnInit {
       options = options.filter(option => option.toLowerCase().includes(filterValue));
       options.sort((a, b) => {
         // if index of somehow turns to bottleneck KMP can be used
-        const idA: number = a.indexOf(filterValue);
-        const idB: number = b.indexOf(filterValue);
+        const idA: number = a.toLowerCase().indexOf(filterValue);
+        const idB: number = b.toLowerCase().indexOf(filterValue);
         if (idA == idB) {
           if (a.length == b.length) {
             return a.localeCompare(b);


### PR DESCRIPTION
Bug polegał na tym, że podczas sortowania komponenty były case sensitive. 
Dlatego przy zapytaniu "a"  "something_Abc".indexOf("a") dawał -1, co czyniło go mniejszym od 0 dla "aaa".